### PR TITLE
Use ** syntax

### DIFF
--- a/django_nextjs/render.py
+++ b/django_nextjs/render.py
@@ -40,7 +40,7 @@ def _get_cookies(request):
     (i.e. dont use HTTP unsafe methods or GraphQL mutations).
     https://docs.djangoproject.com/en/3.2/ref/csrf/#is-posting-an-arbitrary-csrf-token-pair-cookie-and-post-data-a-vulnerability
     """
-    return request.COOKIES | {settings.CSRF_COOKIE_NAME: get_csrf_token(request)}
+    return {**request.COOKIES, **{settings.CSRF_COOKIE_NAME: get_csrf_token(request)}}
 
 
 def _get_headers(request):

--- a/django_nextjs/render.py
+++ b/django_nextjs/render.py
@@ -40,7 +40,7 @@ def _get_cookies(request):
     (i.e. dont use HTTP unsafe methods or GraphQL mutations).
     https://docs.djangoproject.com/en/3.2/ref/csrf/#is-posting-an-arbitrary-csrf-token-pair-cookie-and-post-data-a-vulnerability
     """
-    return {**request.COOKIES, **{settings.CSRF_COOKIE_NAME: get_csrf_token(request)}}
+    return {**request.COOKIES, settings.CSRF_COOKIE_NAME: get_csrf_token(request)}
 
 
 def _get_headers(request):


### PR DESCRIPTION
I'm unable to use the library on a Python 3.8.5 environment, it complaints about the following issue:
```
unsupported operand type(s) for |: 'dict' and 'dict'
```
Couldn't the library just use the `**` syntax, which is supported starting from Python 3.5? 