### PR TITLE
Fix NextJS 13 + AppRouter client-side navigation

### DIFF
--- a/django_nextjs/render.py
+++ b/django_nextjs/render.py
@@ -49,15 +49,33 @@ def _get_nextjs_request_cookies(request: HttpRequest):
 
 
 def _get_nextjs_request_headers(request: HttpRequest, headers: Union[Dict, None] = None):
+    # These headers are used by NextJS to indicate if a request is expecting a full HTML
+    # response, or an RSC response.
+    server_component_header_names = [
+        "Rsc",
+        "Next-Router-State-Tree",
+        "Next-Router-Prefetch",
+        "Next-Url",
+        "Cookie",
+        "Accept-Encoding",
+    ]
+
+    server_component_headers = {}
+
+    for server_component_header in server_component_header_names:
+        if request.headers.get(server_component_header) is not None:
+            server_component_headers[server_component_header.lower()] = request.headers[server_component_header]
+
     return {
         "x-real-ip": request.headers.get("X-Real-Ip", "") or request.META.get("REMOTE_ADDR", ""),
         "user-agent": request.headers.get("User-Agent", ""),
+        **server_component_headers,
         **({} if headers is None else headers),
     }
 
 
 def _get_nextjs_response_headers(headers: MultiMapping[str]) -> Dict:
-    useful_header_keys = ("Location",)
+    useful_header_keys = ("Location", "Vary", "Content-Type")
     return {key: headers[key] for key in useful_header_keys if key in headers}
 
 


### PR DESCRIPTION
This PR implements the changes I mentioned in issue #27, namely forwarding the required headers along to the NextJS server, and extracting the required headers from its response.

I also wanted to note that in order for nginx to forward the `Rsc` header to Django, you need something like the following: 
```conf
    location / {
        set $upstream_app MY_DJANGO_URL;
        proxy_pass http://$upstream_app:8000;
        proxy_set_header Host $host;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Real-Ip $proxy_add_x_forwarded_for;
        proxy_pass_header Rsc;  # < ----- This needs to be added
    }
```
I think this is worth documenting since the README has a recommended nginx config already but I wasn't sure how best to include it since the sample config doesn't have a `location` block for Django.