### PR TITLE
Do not include cookies with empty key

### DIFF
--- a/django_nextjs/render.py
+++ b/django_nextjs/render.py
@@ -49,7 +49,7 @@ def _get_nextjs_request_cookies(request: HttpRequest):
     (i.e. dont use HTTP unsafe methods or GraphQL mutations).
     https://docs.djangoproject.com/en/3.2/ref/csrf/#is-posting-an-arbitrary-csrf-token-pair-cookie-and-post-data-a-vulnerability
     """
-    unreserved_cookies = {k: v for k, v in request.COOKIES.items() if not morsel.isReservedKey(k) and k and v}
+    unreserved_cookies = {k: v for k, v in request.COOKIES.items() if k and v and not morsel.isReservedKey(k)}
     return {**unreserved_cookies, settings.CSRF_COOKIE_NAME: get_csrf_token(request)}
 
 

--- a/django_nextjs/render.py
+++ b/django_nextjs/render.py
@@ -49,7 +49,7 @@ def _get_nextjs_request_cookies(request: HttpRequest):
     (i.e. dont use HTTP unsafe methods or GraphQL mutations).
     https://docs.djangoproject.com/en/3.2/ref/csrf/#is-posting-an-arbitrary-csrf-token-pair-cookie-and-post-data-a-vulnerability
     """
-    unreserved_cookies = {k: v for k, v in request.COOKIES.items() if not morsel.isReservedKey(k) and v}
+    unreserved_cookies = {k: v for k, v in request.COOKIES.items() if not morsel.isReservedKey(k) and k and v}
     return {**unreserved_cookies, settings.CSRF_COOKIE_NAME: get_csrf_token(request)}
 
 

--- a/django_nextjs/render.py
+++ b/django_nextjs/render.py
@@ -49,7 +49,7 @@ def _get_nextjs_request_cookies(request: HttpRequest):
     (i.e. dont use HTTP unsafe methods or GraphQL mutations).
     https://docs.djangoproject.com/en/3.2/ref/csrf/#is-posting-an-arbitrary-csrf-token-pair-cookie-and-post-data-a-vulnerability
     """
-    unreserved_cookies = {k: v for k, v in request.COOKIES.items() if not morsel.isReservedKey(k)}
+    unreserved_cookies = {k: v for k, v in request.COOKIES.items() if not morsel.isReservedKey(k) and v}
     return {**unreserved_cookies, settings.CSRF_COOKIE_NAME: get_csrf_token(request)}
 
 


### PR DESCRIPTION
I got the following error:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/asgiref/sync.py", line 518, in thread_handler
    raise exc_info[1]
  File "/usr/local/lib/python3.11/site-packages/django/core/handlers/exception.py", line 42, in inner
    response = await get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/asgiref/sync.py", line 518, in thread_handler
    raise exc_info[1]
  File "/usr/local/lib/python3.11/site-packages/django/core/handlers/base.py", line 253, in _get_response_async
    response = await wrapped_callback(
               ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/views/decorators/clickjacking.py", line 50, in _view_wrapper
    response = await view_func(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/website/app_next/views.py", line 37, in get
    return await nextjs_request(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/website/app_next/functions.py", line 8, in nextjs_request
    return await render_nextjs_page(
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django_nextjs/render.py", line 149, in render_nextjs_page
    content, status, response_headers = await _render_nextjs_page_to_string(
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django_nextjs/render.py", line 102, in _render_nextjs_page_to_string
    async with aiohttp.ClientSession(
               ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/aiohttp/client.py", line 305, in __init__
    self._cookie_jar.update_cookies(cookies)
  File "/usr/local/lib/python3.11/site-packages/aiohttp/cookiejar.py", line 179, in update_cookies
    tmp[name] = cookie  # type: ignore[assignment]
    ~~~^^^^^^
  File "/usr/local/lib/python3.11/http/cookies.py", line 498, in __setitem__
    self.__set(key, rval, cval)
  File "/usr/local/lib/python3.11/http/cookies.py", line 488, in __set
    M.set(key, real_value, coded_value)
  File "/usr/local/lib/python3.11/http/cookies.py", line 353, in set
    raise CookieError('Illegal key %r' % (key,))
http.cookies.CookieError: Illegal key ''
```

To fix this I added an extra check that the cookie is not passed through when the value of the cookie is empty.