### PR TITLE
Add config option to opt-out of generating CSRF token

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,12 +267,20 @@ Default settings:
 ```python
     NEXTJS_SETTINGS = {
         "nextjs_server_url": "http://127.0.0.1:3000",
+        "ensure_csrf_token": True,
     }
 ```
 
 ### `nextjs_server_url`
 
 The URL of Next.js server (started by `npm run dev` or `npm run start`)
+
+### `ensure_csrf_token`
+
+If user does not have a CSRF token, ensure that one is generated and included in the initial request to the NextJS
+server, by calling Django's `django.middleware.csrf.get_token`.  If `django.middleware.csrf.CsrfViewMiddleware` is
+installed, the initial response will include a `Set-Cookie` header to persist the CSRF token value on the client.
+This behaviour is enabled by default.
 
 ## Development
 

--- a/django_nextjs/app_settings.py
+++ b/django_nextjs/app_settings.py
@@ -5,3 +5,5 @@ from django.conf import settings
 NEXTJS_SETTINGS = getattr(settings, "NEXTJS_SETTINGS", {})
 
 NEXTJS_SERVER_URL = NEXTJS_SETTINGS.get("nextjs_server_url", "http://127.0.0.1:3000")
+
+ENSURE_CSRF_TOKEN = NEXTJS_SETTINGS.get("ensure_csrf_token", True)

--- a/django_nextjs/render.py
+++ b/django_nextjs/render.py
@@ -10,7 +10,7 @@ from django.middleware.csrf import get_token as get_csrf_token
 from django.template.loader import render_to_string
 from multidict import MultiMapping
 
-from .app_settings import NEXTJS_SERVER_URL
+from .app_settings import ENSURE_CSRF_TOKEN, NEXTJS_SERVER_URL
 from .utils import filter_mapping_obj
 
 morsel = Morsel()
@@ -49,7 +49,9 @@ def _get_nextjs_request_cookies(request: HttpRequest):
     https://docs.djangoproject.com/en/3.2/ref/csrf/#is-posting-an-arbitrary-csrf-token-pair-cookie-and-post-data-a-vulnerability
     """
     unreserved_cookies = {k: v for k, v in request.COOKIES.items() if k and not morsel.isReservedKey(k)}
-    return {**unreserved_cookies, settings.CSRF_COOKIE_NAME: get_csrf_token(request)}
+    if ENSURE_CSRF_TOKEN is True and settings.CSRF_COOKIE_NAME not in unreserved_cookies:
+        unreserved_cookies[settings.CSRF_COOKIE_NAME] = get_csrf_token(request)
+    return unreserved_cookies
 
 
 def _get_nextjs_request_headers(request: HttpRequest, headers: Union[Dict, None] = None):


### PR DESCRIPTION
- This adds a config option `ensure_csrf_token` to opt-out of `django-nextjs` automatically generating a CSRF token to include in the request to the NextJS server.  It preserves the current behavior by defaulting to `True`.
  - The comment in `_get_nextjs_request_cookies` indicates this was done to support a GraphQL use case.  But in our project, the behavior is undesirable because of the side-effect of including a `Set-Cookie` header (see next bullet).

- A new CSRF token value was being generated on every request.  This causes Django's `CsrfViewMiddleware` to include a `Set-Cookie` header on every response, making all responses from `django-nextjs` un-cacheable.  This updates the behavior to only generate a CSRF token if the `settings.CSRF_COOKIE_NAME` cookie is not already present in the request.