### PR TITLE
Include client's User-Agent header in requests to NextJS server from NextJSProxyView

### DIFF
--- a/django_nextjs/proxy.py
+++ b/django_nextjs/proxy.py
@@ -91,10 +91,12 @@ class NextJSProxyView(View):
 
     def get(self, request):
         url = NEXTJS_SERVER_URL + request.path + "?" + request.GET.urlencode()
+        headers = {}
+        for header in ["Cookie", "User-Agent"]:
+            if header in request.headers:
+                headers[header] = request.headers[header]
 
-        urllib_response = urllib.request.urlopen(
-            urllib.request.Request(url, headers={"Cookie": request.headers.get("Cookie")})
-        )
+        urllib_response = urllib.request.urlopen(urllib.request.Request(url, headers=headers))
 
         return http.StreamingHttpResponse(
             self._iter_content(urllib_response), headers={"Content-Type": urllib_response.headers.get("Content-Type")}


### PR DESCRIPTION
This includes the end user's `User-Agent` header value in requests to the NextJS server from the `NextJSProxyView` development proxy.

We ran into an issue with using `req.headers['user-agent']` in `getServerSideProps` to vary API calls between desktop and mobile clients.  The `User-Agent` value was from the Django server, `Python-urllib/3.8`.  (Note that our issue appears fixed after converting from the Pages Router to the App Router, but this could be useful for apps that have not yet converted to App Router.)