### PR TITLE
Add streaming support for Next.js App Router

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,33 +161,24 @@ async def jobs(request):
     return await render_nextjs_page(request)
 ```
 
-#### Using `stream_nextjs_page` with Next.js App Router
+#### Using `nextjs_page` with `stream=True` (Recommended)
 
-If you're using the [Next.js App Router](https://nextjs.org/docs/app) (introduced in Next.js 13+), you can use the `stream_nextjs_page` function to stream the HTML response directly from Next.js to the client. This approach is particularly useful for server-side rendering with streaming support to show an [instant loading state](https://nextjs.org/docs/app/building-your-application/routing/loading-ui-and-streaming#instant-loading-states) from the Next.js server while the content of a route segment loads.
+If you're using the [Next.js App Router](https://nextjs.org/docs/app) (introduced in Next.js 13+), you can enable streaming by setting the `stream=True` parameter in the `nextjs_page` function. This allows the HTML response to be streamed directly from the Next.js server to the client. This approach is particularly useful for server-side rendering with streaming support to show an [instant loading state](https://nextjs.org/docs/app/building-your-application/routing/loading-ui-and-streaming#instant-loading-states) from the Next.js server while the content of a route segment loads.
 
-Here's an example of how to use it:
-
-```python
-from django_nextjs.render import stream_nextjs_page
-
-async def my_page(request):
-  # Your custom logic (if needed)
-  return await stream_nextjs_page(request)
-```
-
-**Note:** When using `stream_nextjs_page`, you cannot use a custom HTML template in Django, as the HTML is streamed directly from the Next.js server.
-
-Add the view to your `urlpatterns`:
+Here's an example:
 
 ```python
-from django.urls import path
+from django_nextjs.views import nextjs_page
 
 urlpatterns = [
-  path("/my-page", my_page, name="my_page"),
+  path("/nextjs/page", nextjs_page(stream=True), name="nextjs_page"),
 ]
 ```
 
-This method ensures compatibility with the App Router's streaming capabilities while maintaining seamless integration with Django.
+**Considerations:**
+
+- When using `stream_nextjs_page`, you cannot use a custom HTML template in Django, as the HTML is streamed directly from the Next.js server.
+- The `stream` parameter is currently set to `False` by default for backward compatibility. However, in future releases, it will be set to `True` by default. We recommend updating your code to explicitly enable streaming to prepare for this change.
 
 ## Customizing the HTML Response
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ urlpatterns = [
 **Considerations:**
 
 - When using `stream_nextjs_page`, you cannot use a custom HTML template in Django, as the HTML is streamed directly from the Next.js server.
-- The `stream` parameter is currently set to `False` by default for backward compatibility. However, in future releases, it will be set to `True` by default. We recommend updating your code to explicitly enable streaming to prepare for this change.
+- The `stream` parameter will default to `True` in future releases. Currently, it is set to `False` for backward compatibility. To avoid breaking changes, we recommend explicitly setting `stream=False` if you are customizing HTML and do not want to use streaming.
 
 ## Customizing the HTML Response
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,34 @@ async def jobs(request):
     return await render_nextjs_page(request)
 ```
 
+#### Using `stream_nextjs_page` with Next.js App Router
+
+If you're using the [Next.js App Router](https://nextjs.org/docs/app) (introduced in Next.js 13+), you can use the `stream_nextjs_page` function to stream the HTML response directly from Next.js to the client. This approach is particularly useful for server-side rendering with streaming support to show an [instant loading state](https://nextjs.org/docs/app/building-your-application/routing/loading-ui-and-streaming#instant-loading-states) from the Next.js server while the content of a route segment loads.
+
+Here's an example of how to use it:
+
+```python
+from django_nextjs.render import stream_nextjs_page
+
+async def my_page(request):
+  # Your custom logic (if needed)
+  return await stream_nextjs_page(request)
+```
+
+**Note:** When using `stream_nextjs_page`, you cannot use a custom HTML template in Django, as the HTML is streamed directly from the Next.js server.
+
+Add the view to your `urlpatterns`:
+
+```python
+from django.urls import path
+
+urlpatterns = [
+  path("/my-page", my_page, name="my_page"),
+]
+```
+
+This method ensures compatibility with the App Router's streaming capabilities while maintaining seamless integration with Django.
+
 ## Customizing the HTML Response
 
 You can modify the HTML code that Next.js returns in your Django code.

--- a/django_nextjs/render.py
+++ b/django_nextjs/render.py
@@ -70,7 +70,7 @@ def _get_nextjs_request_headers(request: HttpRequest, headers: Union[Dict, None]
     }
 
 
-def _get_nextjs_response_headers(headers: MultiMapping[str], stream: bool = False) -> Dict:
+def _get_nextjs_response_headers(headers: MultiMapping[str]) -> Dict:
     return filter_mapping_obj(
         headers,
         selected_keys=[
@@ -83,7 +83,6 @@ def _get_nextjs_response_headers(headers: MultiMapping[str], stream: bool = Fals
             "Connection",
             "Date",
             "Keep-Alive",
-            *(["Transfer-Encoding"] if stream else []),
         ],
     )
 
@@ -181,7 +180,7 @@ async def stream_nextjs_page(
             cookies=_get_nextjs_request_cookies(request),
             headers=_get_nextjs_request_headers(request, headers)
         )
-        response_headers = _get_nextjs_response_headers(nextjs_response.headers, stream=True)
+        response_headers = _get_nextjs_response_headers(nextjs_response.headers)
 
         async def stream_nextjs_response():
             try:

--- a/django_nextjs/render.py
+++ b/django_nextjs/render.py
@@ -178,7 +178,7 @@ async def stream_nextjs_page(
             params=params,
             allow_redirects=allow_redirects,
             cookies=_get_nextjs_request_cookies(request),
-            headers=_get_nextjs_request_headers(request, headers)
+            headers=_get_nextjs_request_headers(request, headers),
         )
         response_headers = _get_nextjs_response_headers(nextjs_response.headers)
 

--- a/django_nextjs/render.py
+++ b/django_nextjs/render.py
@@ -5,7 +5,7 @@ from urllib.parse import quote
 import aiohttp
 from asgiref.sync import sync_to_async
 from django.conf import settings
-from django.http import HttpRequest, HttpResponse
+from django.http import HttpRequest, HttpResponse, StreamingHttpResponse
 from django.middleware.csrf import get_token as get_csrf_token
 from django.template.loader import render_to_string
 from multidict import MultiMapping
@@ -78,6 +78,12 @@ def _get_nextjs_response_headers(headers: MultiMapping[str]) -> Dict:
             "Vary",
             "Content-Type",
             "Set-Cookie",
+            "Link",
+            "Transfer-Encoding",
+            "Cache-Control",
+            "Connection",
+            "Date",
+            "Keep-Alive",
         ],
     )
 
@@ -150,3 +156,38 @@ async def render_nextjs_page(
         headers=headers,
     )
     return HttpResponse(content=content, status=status, headers=response_headers)
+
+
+async def stream_nextjs_page(
+    request: HttpRequest,
+    headers: Union[Dict, None] = None,
+    allow_redirects: bool = False,
+):
+    """
+    Stream a Next.js page response.
+    This function is used to stream the response from a Next.js server.
+    """
+    page_path = quote(request.path_info.lstrip("/"))
+    params = [(k, v) for k in request.GET.keys() for v in request.GET.getlist(k)]
+    next_url = f"{NEXTJS_SERVER_URL}/{page_path}"
+
+    session = aiohttp.ClientSession(
+        cookies=_get_nextjs_request_cookies(request),
+        headers=_get_nextjs_request_headers(request, headers),
+    )
+    nextjs_response = await session.get(next_url, params=params, allow_redirects=allow_redirects)
+    response_headers = _get_nextjs_response_headers(nextjs_response.headers)
+
+    async def stream_nextjs_response():
+        try:
+            async for chunk in nextjs_response.content.iter_any():
+                yield chunk
+        finally:
+            await nextjs_response.release()
+            await session.close()
+
+    return StreamingHttpResponse(
+        stream_nextjs_response(),
+        status=nextjs_response.status,
+        headers=response_headers,
+    )

--- a/django_nextjs/render.py
+++ b/django_nextjs/render.py
@@ -70,7 +70,7 @@ def _get_nextjs_request_headers(request: HttpRequest, headers: Union[Dict, None]
     }
 
 
-def _get_nextjs_response_headers(headers: MultiMapping[str]) -> Dict:
+def _get_nextjs_response_headers(headers: MultiMapping[str], stream: bool = False) -> Dict:
     return filter_mapping_obj(
         headers,
         selected_keys=[
@@ -79,11 +79,11 @@ def _get_nextjs_response_headers(headers: MultiMapping[str]) -> Dict:
             "Content-Type",
             "Set-Cookie",
             "Link",
-            "Transfer-Encoding",
             "Cache-Control",
             "Connection",
             "Date",
             "Keep-Alive",
+            "Transfer-Encoding" if stream else None,
         ],
     )
 
@@ -160,8 +160,8 @@ async def render_nextjs_page(
 
 async def stream_nextjs_page(
     request: HttpRequest,
-    headers: Union[Dict, None] = None,
     allow_redirects: bool = False,
+    headers: Union[Dict, None] = None,
 ):
     """
     Stream a Next.js page response.
@@ -176,7 +176,7 @@ async def stream_nextjs_page(
         headers=_get_nextjs_request_headers(request, headers),
     )
     nextjs_response = await session.get(next_url, params=params, allow_redirects=allow_redirects)
-    response_headers = _get_nextjs_response_headers(nextjs_response.headers)
+    response_headers = _get_nextjs_response_headers(nextjs_response.headers, stream=True)
 
     async def stream_nextjs_response():
         try:

--- a/django_nextjs/render.py
+++ b/django_nextjs/render.py
@@ -83,7 +83,7 @@ def _get_nextjs_response_headers(headers: MultiMapping[str], stream: bool = Fals
             "Connection",
             "Date",
             "Keep-Alive",
-            "Transfer-Encoding" if stream else None,
+            *(["Transfer-Encoding"] if stream else []),
         ],
     )
 

--- a/django_nextjs/views.py
+++ b/django_nextjs/views.py
@@ -13,9 +13,7 @@ def nextjs_page(
     headers: Union[Dict, None] = None,
 ):
     if stream and (template_name or context or using):
-        raise ValueError(
-            "When 'stream' parameter is True, 'template_name', 'context', and 'using' cannot be used together."
-        )
+        raise ValueError("When 'stream' is set to True, you should not use 'template_name', 'context', or 'using'")
 
     async def view(request, *args, **kwargs):
         if stream:

--- a/django_nextjs/views.py
+++ b/django_nextjs/views.py
@@ -1,17 +1,26 @@
 from typing import Dict, Union
 
-from .render import render_nextjs_page
+from .render import render_nextjs_page, stream_nextjs_page
 
 
 def nextjs_page(
     *,
+    stream: bool = False,
     template_name: str = "",
     context: Union[Dict, None] = None,
     using: Union[str, None] = None,
     allow_redirects: bool = False,
     headers: Union[Dict, None] = None,
 ):
+    if stream and (template_name or context or using):
+        raise ValueError(
+            "When 'stream' parameter is True, 'template_name', 'context', and 'using' cannot be used together."
+        )
+
     async def view(request, *args, **kwargs):
+        if stream:
+            return await stream_nextjs_page(request=request, allow_redirects=allow_redirects, headers=headers)
+
         return await render_nextjs_page(
             request=request,
             template_name=template_name,


### PR DESCRIPTION
This PR adds a new stream_nextjs_page function that enables streaming responses directly from Next.js to the client. This feature is particularly valuable for projects using Next.js 13+ with the App Router, supporting key Next.js features like instant loading states and streaming server components. Before this PR, the package couldn't properly support Next.js App Router's streaming capabilities, which are becoming increasingly important with Next.js 13+ and particularly Next.js 15. Features like loading UI, streaming, and suspense boundaries in Next.js require the ability to stream HTML rather than waiting for the full response.

**Note:** When using stream_nextjs_page, you cannot use a custom HTML template in Django, as the HTML is streamed directly from the Next.js server.